### PR TITLE
Multicorn aggregation/grouping pushdown support

### DIFF
--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -105,11 +105,19 @@ class ElasticsearchFDW(ForeignDataWrapper):
             },
         }
 
-    def explain(self, quals, columns, sortkeys=None, verbose=False):
-        query, _ = self._get_query(quals)
+    def explain(
+        self,
+        quals,
+        columns,
+        sortkeys=None,
+        aggs=None,
+        group_clauses=None,
+        verbose=False,
+    ):
+        query, _ = self._get_query(quals, aggs=aggs, group_clauses=group_clauses)
         return [
             "Elasticsearch query to %s" % self.client,
-            "Query: %s" % json.dumps(query),
+            "Query: %s" % json.dumps(query, indent=4),
         ]
 
     def execute(self, quals, columns, aggs=None, group_clauses=None):
@@ -337,7 +345,8 @@ class ElasticsearchFDW(ForeignDataWrapper):
                 if "after_key" not in response["aggregations"]["group_buckets"]:
                     break
 
-                query["aggs"]["group_buckets"]["composite"]["after"] = \
-                    response["aggregations"]["group_buckets"]["after_key"]
+                query["aggs"]["group_buckets"]["composite"]["after"] = response[
+                    "aggregations"
+                ]["group_buckets"]["after_key"]
 
                 response = self.client.search(size=0, body=query, **self.arguments)

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -10,7 +10,7 @@ from elasticsearch import Elasticsearch
 from multicorn import ForeignDataWrapper
 from multicorn.utils import log_to_postgres as log2pg
 
-from ._es_query import quals_to_es
+from ._es_query import _PG_TO_ES_AGG_FUNCS, quals_to_es
 
 
 class ElasticsearchFDW(ForeignDataWrapper):
@@ -96,13 +96,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
     def can_pushdown_upperrel(self):
         return {
             "groupby_supported": True,
-            "agg_functions": {
-                "avg": "avg",
-                "max": "max",
-                "min": "min",
-                "sum": "sum",
-                "count": "value_count",
-            },
+            "agg_functions": _PG_TO_ES_AGG_FUNCS,
         }
 
     def explain(

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -93,6 +93,18 @@ class ElasticsearchFDW(ForeignDataWrapper):
             )
             return (0, 0)
 
+    def can_pushdown_upperrel(self):
+        return {
+            "groupby_supported": True,
+            "agg_functions": {
+                "avg": "avg",
+                "max": "max",
+                "min": "min",
+                "sum": "sum",
+                "count": "value_count",
+            }
+        }
+
     def explain(self, quals, columns, sortkeys=None, verbose=False):
         query, _ = self._get_query(quals)
         return [

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -70,9 +70,19 @@ def _qual_to_es(qual, column_map=None):
         )
 
 
-def quals_to_es(quals, ignore_columns=None, column_map=None):
+def quals_to_es(quals, aggs=None, ignore_columns=None, column_map=None):
     """Convert a list of Multicorn quals to an ElasticSearch query"""
     ignore_columns = ignore_columns or []
+    if aggs is not None:
+        return {
+            "aggs": {
+                "res": {
+                    aggs["operation"]: {
+                        "field": aggs["column"]
+                    }
+                }
+            }
+        }
     return {
         "query": {
             "bool": {

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -68,7 +68,9 @@ def _qual_to_es(qual, column_map=None):
         return _base_qual_to_es(qual.field_name, qual.operator, qual.value, column_map)
 
 
-def quals_to_es(quals, aggs=None, group_clauses=None, ignore_columns=None, column_map=None):
+def quals_to_es(
+    quals, aggs=None, group_clauses=None, ignore_columns=None, column_map=None
+):
     """Convert a list of Multicorn quals to an ElasticSearch query"""
     ignore_columns = ignore_columns or []
 
@@ -80,16 +82,14 @@ def quals_to_es(quals, aggs=None, group_clauses=None, ignore_columns=None, colum
         }
 
         if group_clauses is None:
-            return {
-                "aggs": aggs_query
-            }
+            return {"aggs": aggs_query}
 
     if group_clauses is not None:
         group_query = {
             "group_buckets": {
                 "composite": {
                     "sources": [
-                        { column: { "terms": { "field": column } } }
+                        {column: {"terms": {"field": column}}}
                         for column in group_clauses
                     ]
                 }
@@ -99,9 +99,7 @@ def quals_to_es(quals, aggs=None, group_clauses=None, ignore_columns=None, colum
         if aggs is not None:
             group_query["group_buckets"]["aggregations"] = aggs_query
 
-        return {
-            "aggs": group_query
-        }
+        return {"aggs": group_query}
 
     # Regular query
     return {

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -65,9 +65,7 @@ def _qual_to_es(qual, column_map=None):
             }
         }
     else:
-        return _base_qual_to_es(
-            qual.field_name, qual.operator, qual.value, column_map
-        )
+        return _base_qual_to_es(qual.field_name, qual.operator, qual.value, column_map)
 
 
 def quals_to_es(quals, aggs=None, ignore_columns=None, column_map=None):
@@ -76,11 +74,8 @@ def quals_to_es(quals, aggs=None, ignore_columns=None, column_map=None):
     if aggs is not None:
         return {
             "aggs": {
-                "res": {
-                    aggs["operation"]: {
-                        "field": aggs["column"]
-                    }
-                }
+                agg_name: {agg_props["operation"]: {"field": agg_props["column"]}}
+                for agg_name, agg_props in aggs.items()
             }
         }
     return {

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -12,6 +12,14 @@ _RANGE_OPS = {
     "<=": "lte",
 }
 
+_PG_TO_ES_AGG_FUNCS = {
+    "avg": "avg",
+    "max": "max",
+    "min": "min",
+    "sum": "sum",
+    "count": "value_count",
+}
+
 
 def _base_qual_to_es(col, op, value, column_map=None):
     if column_map:
@@ -77,7 +85,11 @@ def quals_to_es(
     # Aggreagtion/grouping queries
     if aggs is not None:
         aggs_query = {
-            agg_name: {agg_props["function"]: {"field": agg_props["column"]}}
+            agg_name: {
+                _PG_TO_ES_AGG_FUNCS[agg_props["function"]]: {
+                    "field": agg_props["column"]
+                }
+            }
             for agg_name, agg_props in aggs.items()
         }
 

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -82,7 +82,7 @@ def quals_to_es(
     """Convert a list of Multicorn quals to an ElasticSearch query"""
     ignore_columns = ignore_columns or []
 
-    # Aggreagtion/grouping queries
+    # Aggregation/grouping queries
     if aggs is not None:
         aggs_query = {
             agg_name: {


### PR DESCRIPTION
Enable aggregation/grouping support offered in Multicorn through the accompanying PR https://github.com/splitgraph/Multicorn/pull/1.

- Provides a response to `can_pushdown_upperrel` with relevant details so that Multicorn can decide whether and what to push to the Python side. 
- Takes care of differences in the query and responses for the cases with and without aggregations.

Here are two instructive examples of the translated aggregation queries:
1. With `GROUP BY`
```sql
sgr@localhost:splitgraph> explain select column5, column4, min(column2) from es.iris group by column4, column5
+--------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                 |
|--------------------------------------------------------------------------------------------|
| Foreign Scan  (cost=1.00..1.00 rows=1 width=1)                                             |
|   Multicorn: Elasticsearch query to <Elasticsearch([{'host': 'es01-test', 'port': 9200}])> |
|   Multicorn: Query: {                                                                      |
|     "aggs": {                                                                              |
|         "group_buckets": {                                                                 |
|             "composite": {                                                                 |
|                 "sources": [                                                               |
|                     {                                                                      |
|                         "column5": {                                                       |
|                             "terms": {                                                     |
|                                 "field": "column5"                                         |
|                             }                                                              |
|                         }                                                                  |
|                     },                                                                     |
|                     {                                                                      |
|                         "column4": {                                                       |
|                             "terms": {                                                     |
|                                 "field": "column4"                                         |
|                             }                                                              |
|                         }                                                                  |
|                     }                                                                      |
|                 ],                                                                         |
|                 "size": 1000                                                               |
|             },                                                                             |
|             "aggregations": {                                                              |
|                 "min.column2": {                                                           |
|                     "min": {                                                               |
|                         "field": "column2"                                                 |
|                     }                                                                      |
|                 }                                                                          |
|             }                                                                              |
|         }                                                                                  |
|     }                                                                                      |
| }                                                                                          |
+--------------------------------------------------------------------------------------------+
```
2. Without `GROUP BY`
```sql
sgr@localhost:splitgraph> explain analyze select sum(column4), max(column4), sum(column4), min(column2), avg(column3)  from es.iris
+--------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                 |
|--------------------------------------------------------------------------------------------|
| Foreign Scan  (cost=1.00..1.00 rows=1 width=1) (actual time=2.344..2.350 rows=1 loops=1)   |
|   Multicorn: Elasticsearch query to <Elasticsearch([{'host': 'es01-test', 'port': 9200}])> |
|   Multicorn: Query: {                                                                      |
|     "aggs": {                                                                              |
|         "sum.column4": {                                                                   |
|             "sum": {                                                                       |
|                 "field": "column4"                                                         |
|             }                                                                              |
|         },                                                                                 |
|         "max.column4": {                                                                   |
|             "max": {                                                                       |
|                 "field": "column4"                                                         |
|             }                                                                              |
|         },                                                                                 |
|         "min.column2": {                                                                   |
|             "min": {                                                                       |
|                 "field": "column2"                                                         |
|             }                                                                              |
|         },                                                                                 |
|         "avg.column3": {                                                                   |
|             "avg": {                                                                       |
|                 "field": "column3"                                                         |
|             }                                                                              |
|         }                                                                                  |
|     }                                                                                      |
| }                                                                                          |
| Planning Time: 3.123 ms                                                                    |
| Execution Time: 2.467 ms                                                                   |
+--------------------------------------------------------------------------------------------+
```

CU-1t1wycg