### PR TITLE
ES Agg pushdown v2

### DIFF
--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -10,7 +10,7 @@ from elasticsearch import Elasticsearch
 from multicorn import ForeignDataWrapper
 from multicorn.utils import log_to_postgres as log2pg
 
-from ._es_query import _PG_TO_ES_AGG_FUNCS, quals_to_es
+from ._es_query import _PG_TO_ES_AGG_FUNCS, _OPERATORS_SUPPORTED, quals_to_es
 
 
 class ElasticsearchFDW(ForeignDataWrapper):
@@ -97,6 +97,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
         return {
             "groupby_supported": True,
             "agg_functions": _PG_TO_ES_AGG_FUNCS,
+            "operators_supported": _OPERATORS_SUPPORTED,
         }
 
     def explain(

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -321,7 +321,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
             for agg_name in aggs:
                 if agg_name == "count.*":
                     # COUNT(*) is a special case, since it doesn't have a
-                    # corresponding aggregation primitice in ES
+                    # corresponding aggregation primitive in ES
                     result[agg_name] = response["hits"]["total"]["value"]
                     continue
 

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -44,7 +44,7 @@ def _base_qual_to_es(col, op, value, column_map=None):
         return {"bool": {"must_not": {"term": {col: value}}}}
 
     if op == "~~":
-        return {"match": {col: value.replace("%", "*")}}
+        return {"wildcard": {col: value.replace("%", "*")}}
 
     # For unknown operators, get everything
     return {"match_all": {}}

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -35,10 +35,14 @@ def _convert_pattern_match_to_es(expr):
             return "%"
         elif matchobj.group(0) == "\_":
             return "_"
+        elif matchobj.group(0) == "*":
+            return "\\*"
+        elif matchobj.group(0) == "?":
+            return "\\?"
         elif matchobj.group(0) == "\\\\":
             return "\\"
 
-    return re.sub(r'\\\\|\\?%|\\?_', _pg_es_pattern_map, fr"{expr}")
+    return re.sub(r'\\\\|\\?%|\\?_|\*|\?', _pg_es_pattern_map, fr"{expr}")
 
 
 def _base_qual_to_es(col, op, value, column_map=None):

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -82,19 +82,17 @@ def quals_to_es(
     """Convert a list of Multicorn quals to an ElasticSearch query"""
     ignore_columns = ignore_columns or []
 
-    query = {}
-    if quals is not None and len(quals) > 0:
-        query = {
-            "query": {
-                "bool": {
-                    "must": [
-                        _qual_to_es(q, column_map)
-                        for q in quals
-                        if q.field_name not in ignore_columns
-                    ]
-                }
+    query = {
+        "query": {
+            "bool": {
+                "must": [
+                    _qual_to_es(q, column_map)
+                    for q in quals
+                    if q.field_name not in ignore_columns
+                ]
             }
         }
+    }
 
     # Aggregation/grouping queries
     if aggs is not None:

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -35,8 +35,10 @@ def _convert_pattern_match_to_es(expr):
             return "%"
         elif matchobj.group(0) == "\_":
             return "_"
+        elif matchobj.group(0) == "\\\\":
+            return "\\"
 
-    return re.sub(r'\\?%|\\?_', _pg_es_pattern_map, expr)
+    return re.sub(r'\\\\|\\?%|\\?_', _pg_es_pattern_map, fr"{expr}")
 
 
 def _base_qual_to_es(col, op, value, column_map=None):

--- a/pg_es_fdw/_es_query.py
+++ b/pg_es_fdw/_es_query.py
@@ -22,6 +22,8 @@ _PG_TO_ES_AGG_FUNCS = {
     "count.*": None  # not mapped to a particular function
 }
 
+_OPERATORS_SUPPORTED = [">", ">=", "<", "<=", "=", "<>", "!=", "~~"]
+
 
 def _convert_pattern_match_to_es(expr):
     def _pg_es_pattern_map(matchobj):


### PR DESCRIPTION
Building on the changes from https://github.com/splitgraph/Multicorn/pull/2, extend the ES FDW so that we can push down

- doc filtering stemming from SQL qual (`WHERE`) clauses
- `COUNT(*)`, which does not have a simple equivalent that is suitable for all query translations

CU-1z461e4