### PR TITLE
Simplify ES FDW

### DIFF
--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -96,7 +96,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
     def can_pushdown_upperrel(self):
         return {
             "groupby_supported": True,
-            "agg_functions": _PG_TO_ES_AGG_FUNCS.keys(),
+            "agg_functions": list(_PG_TO_ES_AGG_FUNCS),
             "operators_supported": _OPERATORS_SUPPORTED,
         }
 

--- a/pg_es_fdw/__init__.py
+++ b/pg_es_fdw/__init__.py
@@ -96,7 +96,7 @@ class ElasticsearchFDW(ForeignDataWrapper):
     def can_pushdown_upperrel(self):
         return {
             "groupby_supported": True,
-            "agg_functions": _PG_TO_ES_AGG_FUNCS,
+            "agg_functions": _PG_TO_ES_AGG_FUNCS.keys(),
             "operators_supported": _OPERATORS_SUPPORTED,
         }
 


### PR DESCRIPTION
Instead of returning the entire dict of supported agg functions return only the keys (func names).

CU-23kfzuz